### PR TITLE
Removed issues_url and source_url metadata attributes

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -5,8 +5,8 @@ license          'Apache 2.0'
 description      'Installs and configures ArcGIS'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          '1.1.0'
-issues_url       'https://github.com/ArcGIS/arcgis-cookbook/issues'
-source_url       'https://github.com/ArcGIS/arcgis-cookbook'
+#issues_url       'https://github.com/ArcGIS/arcgis-cookbook/issues'
+#source_url       'https://github.com/ArcGIS/arcgis-cookbook'
 
 depends          'hostsfile'
 depends          'limits'


### PR DESCRIPTION
Issues_url and source_url metadata attributes are not supported by older chef clients
