### PR TITLE
invert order of releases in CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,20 @@ arcgis cookbook CHANGELOG
 
 This file is used to list changes made in each version of the arcgis cookbook.
 
-1.1.1
+2.2.0
 -----
-- Initial release of arcgis cookbook
+- This version supports only ArcGIS 10.4 release software. (Use 1.1.3 version with ArcGIS software 10.3.1 release.)
+- Added 'all_uninstalled' and 'cleanup' recipes
+- Added 'arcgis' top level key to all arcgis cookbook attributes
+- Added support for ArcGIS Pro
+- Using 10.4 federation and HA workflows 
+- Data Store types made configurable (see node['arcgis']['data_store']['types'] attribute)
+- Added :uninstall action to geoevent resource
+
+1.1.3
+-----
+- Added ArcGIS GeoEvent Extension for Server resource
+- Default value of attribute node['data_store']['preferredidentifier'] set to 'hostname' instead of 'ip' 
 
 1.1.2
 -----
@@ -16,17 +27,6 @@ This file is used to list changes made in each version of the arcgis cookbook.
 - Improved 'desktop' and 'licensemanager' recipes
 - Supported domain user accounts
 
-1.1.3
+1.1.1
 -----
-- Added ArcGIS GeoEvent Extension for Server resource
-- Default value of attribute node['data_store']['preferredidentifier'] set to 'hostname' instead of 'ip' 
-
-2.2.0
------
-- This version supports only ArcGIS 10.4 release software. (Use 1.1.3 version with ArcGIS software 10.3.1 release.)
-- Added 'all_uninstalled' and 'cleanup' recipes
-- Added 'arcgis' top level key to all arcgis cookbook attributes
-- Added support for ArcGIS Pro
-- Using 10.4 federation and HA workflows 
-- Data Store types made configurable (see node['arcgis']['data_store']['types'] attribute)
-- Added :uninstall action to geoevent resource
+- Initial release of arcgis cookbook


### PR DESCRIPTION
sweet project!

just a small fix to list releases in descending order from most recent to least recent (as suggested by [keepachangelog](http://keepachangelog.com/)).