### PR TITLE
Configure ArcGIS Server to use Active Directory

### DIFF
--- a/cookbooks/arcgis-server/attributes/server.rb
+++ b/cookbooks/arcgis-server/attributes/server.rb
@@ -34,6 +34,10 @@ default['arcgis']['server'].tap do |server|
   server['web_context_url'] = 'https://' + node['arcgis']['server']['domain_name'] + '/' + node['arcgis']['server']['wa_name']
   server['admin_username'] = 'admin'
   server['admin_password'] = 'changeit'
+  server['active_directory_username'] = node['arcgis']['run_as_user']
+  server['active_directory_password'] = node['arcgis']['run_as_password']
+  server['active_directory_groups_administer'] = 'changeit'
+  server['active_directory_groups_publisher'] = 'changeit'
   server['managed_database'] = ''
   server['replicated_database'] = ''
   server['keystore_file'] = ''
@@ -46,6 +50,7 @@ default['arcgis']['server'].tap do |server|
   server['configure_autostart'] = true
   server['install_system_requirements'] = true
   server['use_join_site_tool'] = false
+  server['configure_active_directory'] = false
 
   unless node['arcgis']['server']['authorization_file'].nil?
     server['cached_authorization_file'] = ::File.join(Chef::Config[:file_cache_path],

--- a/cookbooks/arcgis-server/libraries/server_admin_client.rb
+++ b/cookbooks/arcgis-server/libraries/server_admin_client.rb
@@ -577,6 +577,56 @@ module ArcGIS
 
       validate_response(response)
     end
+    
+    def set_identity_store_to_windows(admin_user, admin_user_password)
+      request = Net::HTTP::Post.new(URI.parse(@server_url + '/admin/security/config/updateIdentityStore').request_uri)
+      
+      request.add_field('Referer', 'referer')
+      
+      token = generate_token()
+      
+      userStoreConfig = {
+        'type' => "WINDOWS",
+        'properties' => {
+          'adminUser' => admin_user,
+          'adminUserPassword' => admin_user_password
+        }
+      }
+      
+      roleStoreConfig = {
+        'type' => "WINDOWS",
+        'properties' => {
+          'adminUser' => admin_user,
+          'adminUserPassword' => admin_user_password
+        }
+      }
+
+      request.set_form_data('userStoreConfig' => userStoreConfig.to_json,
+                            'roleStoreConfig' => roleStoreConfig.to_json,
+                            'token' => token, 
+                            'f' => 'json')
+
+      response = send_request(request, @server_url)
+
+      validate_response(response)
+    end
+    
+    def assign_privileges(rolename, privilege)
+      request = Net::HTTP::Post.new(URI.parse(@server_url + '/admin/security/roles/assignPrivilege').request_uri)
+      
+      request.add_field('Referer', 'referer')
+      
+      token = generate_token()
+      
+      request.set_form_data('rolename' => rolename,
+                            'privilege' => privilege,
+                            'token' => token, 
+                            'f' => 'json')
+
+      response = send_request(request, @server_url)
+
+      validate_response(response)
+    end
 
     private
 

--- a/cookbooks/arcgis-server/recipes/server_active_directory.rb
+++ b/cookbooks/arcgis-server/recipes/server_active_directory.rb
@@ -1,0 +1,40 @@
+#
+# Cookbook Name:: arcgis-server
+# Recipe:: server_active_directory
+#
+# Copyright 2015 Esri
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+if node['platform'] == 'windows'
+  arcgis_server_server 'Couple ArcGIS Server with Active Directory' do
+    server_url node['arcgis']['server']['url']
+    username node['arcgis']['server']['admin_username']
+    password node['arcgis']['server']['admin_password']
+    active_directory_username node['arcgis']['server']['active_directory_username']
+    active_directory_password node['arcgis']['server']['active_directory_password']
+    only_if { node['arcgis']['server']['configure_active_directory'] }
+    action :set_identity_store_to_windows
+  end
+  
+  arcgis_server_server 'Assign ArcGIS Server roles to Active Directory groups' do
+    server_url node['arcgis']['server']['url']
+    username node['arcgis']['server']['admin_username']
+    password node['arcgis']['server']['admin_password']
+    roles_administer node['arcgis']['server']['active_directory_groups_administer']
+    roles_publisher node['arcgis']['server']['active_directory_groups_publisher']
+    only_if { node['arcgis']['server']['configure_active_directory'] }
+    action :assign_privileges
+  end
+end

--- a/cookbooks/arcgis-server/resources/server.rb
+++ b/cookbooks/arcgis-server/resources/server.rb
@@ -19,7 +19,8 @@
 
 actions :system, :install, :uninstall, :update_account, :stop, :start,
         :configure_autostart, :authorize, :create_site, :join_site,
-        :join_cluster, :configure_https, :register_database, :federate
+        :join_cluster, :configure_https, :register_database, :federate,
+        :set_identity_store_to_windows, :assign_privileges
 
 attribute :setup, :kind_of => String
 attribute :product_code, :kind_of => String
@@ -42,6 +43,11 @@ attribute :portal_username, :kind_of => String
 attribute :portal_password, :kind_of => String
 attribute :username, :kind_of => String
 attribute :password, :kind_of => String
+attribute :active_directory_username, :kind_of => String
+attribute :active_directory_password, :kind_of => String
+attribute :roles_administer, :kind_of => Array
+attribute :roles_publisher, :kind_of => Array
+attribute :configure_active_directory, :kind_of => [TrueClass, FalseClass], :default => false
 attribute :server_directories_root, :kind_of => String
 attribute :config_store_connection_string, :kind_of => String
 attribute :config_store_connection_secret, :kind_of => String

--- a/roles/webgis-windows.json
+++ b/roles/webgis-windows.json
@@ -17,6 +17,9 @@
     "server":{
       "admin_username":"admin",
       "admin_password":"changeit",
+      "configure_active_directory":true,
+      "active_directory_groups_administer":["MyDomain\\AGS-Admins1", "MyDomain\\AGS-Admins2"],
+      "active_directory_groups_publisher":["MyDomain\\AGS-Users1", "MyDomain\\AGS-Users2"],
       "setup":"C:\\ArcGIS\\10.5\\Server\\Setup.exe",
       "authorization_file":"C:\\ArcGIS\\10.5\\Authorization_Files\\Server.prvc",
       "keystore_file":"C:\\keystore\\mydomain_com.pfx",


### PR DESCRIPTION
This commit enables the Cookbook to set the ArcGIS Server's identity store to an Active Directory. For the authentication against the Active Directory, the following parameters out of `webgis-windows.json` are used:

- `node['arcgis']['run_as_user']`
- `node['arcgis']['run_as_password']`

To enable the coupling, the parameter `node['arcgis']['server']['configure_active_directory']` within `webgis-windows.json` has to be set to `true`.

Furthermore, the ArcGIS Server's administrators and publishers can be bound to Active Directory groups. For this, the parameters `node['arcgis']['server']['active_directory_groups_administer']` and `node['arcgis']['server']['active_directory_groups_publisher']` have to be set within `webgis-windows.json`. These parameters are arrays, so several Active Directory groups can be set as administrators or publishers.

The new functionality is encapsulated within the recipe `server_active_directory` which is not enabled by default within 'webgis-windows.json' - this can be done on demand.