### PR TITLE
Added source_url, issues_url which adds a link to relevant urls

### DIFF
--- a/cookbooks/arcgis-desktop/Berksfile
+++ b/cookbooks/arcgis-desktop/Berksfile
@@ -1,7 +1,5 @@
-source "https://supermarket.getchef.com"
-
-
+source 'https://supermarket.chef.io'
 
 metadata
 
-cookbook  "windows", "~> 1.38"
+cookbook 'windows', '~> 1.38'

--- a/cookbooks/arcgis-desktop/Gemfile
+++ b/cookbooks/arcgis-desktop/Gemfile
@@ -14,8 +14,6 @@ gem 'berkshelf'
 #   gem "vagrant-omnibus", github: "schisamo/vagrant-omnibus"
 # end
 
-
-
 gem 'test-kitchen'
 gem 'kitchen-vagrant'
 gem 'kitchen-docker'

--- a/cookbooks/arcgis-desktop/metadata.rb
+++ b/cookbooks/arcgis-desktop/metadata.rb
@@ -15,3 +15,6 @@ recipe           'arcgis-desktop::default', 'Installs ArcGIS Desktop'
 recipe           'arcgis-desktop::licensemanager', 'Installs ArcGIS License Manager'
 recipe           'arcgis-desktop::lp-install', 'Installs language packs for ArcGIS Desktop and ArcGIS License Manager.'
 recipe           'arcgis-desktop::uninstall', 'Uninstalls ArcGIS Desktop and ArcGIS License Manager.'
+
+issues_url 'https://github.com/Esri/arcgis-cookbook/issues' if respond_to?(:issues_url)
+source_url 'https://github.com/Esri/arcgis-cookbook' if respond_to?(:source_url)

--- a/cookbooks/arcgis-enterprise/Berksfile
+++ b/cookbooks/arcgis-enterprise/Berksfile
@@ -1,18 +1,16 @@
-source "https://supermarket.getchef.com"
-
-
+source 'https://supermarket.chef.io'
 
 metadata
 
-cookbook  'hostsfile', '~> 2.4'
-cookbook  'limits', '~> 1.0'
-cookbook  'authbind', '~> 0.1'
-cookbook  'iptables', '~> 1.0'
-cookbook  'windows', '~> 1.39'
-cookbook  'openssl', '~> 4.0'
-cookbook  'esri-tomcat', path: '../esri-tomcat'
-cookbook  'esri-iis', path: '../esri-iis'
-cookbook  'tomcat', path: '../tomcat'
-cookbook  'yum-epel', path: '../yum-epel'
-cookbook  'java'
-cookbook  'nfs'
+cookbook 'hostsfile', '~> 2.4'
+cookbook 'limits', '~> 1.0'
+cookbook 'authbind', '~> 0.1'
+cookbook 'iptables', '~> 1.0'
+cookbook 'windows', '~> 1.39'
+cookbook 'openssl', '~> 4.0'
+cookbook 'esri-tomcat', path: '../esri-tomcat'
+cookbook 'esri-iis', path: '../esri-iis'
+cookbook 'tomcat', path: '../tomcat'
+cookbook 'yum-epel', path: '../yum-epel'
+cookbook 'java'
+cookbook 'nfs'

--- a/cookbooks/arcgis-enterprise/metadata.rb
+++ b/cookbooks/arcgis-enterprise/metadata.rb
@@ -46,3 +46,5 @@ recipe 'arcgis-enterprise::webgis_validate', 'Checks if ArcGIS for Server setups
 recipe 'arcgis-enterprise::rds_egdb', 'Creates managed and replicated GeoDatabases in Amazon RDS database'
 recipe 'arcgis-enterprise::sql_alias', 'Creates EGDBHOST alias for Amazon RDS endpoint'
 
+issues_url 'https://github.com/Esri/arcgis-cookbook/issues' if respond_to?(:issues_url)
+source_url 'https://github.com/Esri/arcgis-cookbook' if respond_to?(:source_url)

--- a/cookbooks/arcgis-geoevent/Berksfile
+++ b/cookbooks/arcgis-geoevent/Berksfile
@@ -1,7 +1,5 @@
-source "https://supermarket.getchef.com"
-
-
+source 'https://supermarket.chef.io'
 
 metadata
 
-cookbook  "arcgis-enterprise", path: "../arcgis-enterprise"
+cookbook  'arcgis-enterprise', path: '../arcgis-enterprise'

--- a/cookbooks/arcgis-geoevent/metadata.rb
+++ b/cookbooks/arcgis-geoevent/metadata.rb
@@ -15,3 +15,6 @@ supports         'redhat'
 recipe           'arcgis-geoevent::default', 'Installs and configures ArcGIS GeoEvent Server'
 recipe           'arcgis-geoevent::lp-install', 'Installs language pack for ArcGIS GeoEvent Server.'
 recipe           'arcgis-geoevent::uninstall', 'Uninstalls ArcGIS GeoEvent Server'
+
+issues_url 'https://github.com/Esri/arcgis-cookbook/issues' if respond_to?(:issues_url)
+source_url 'https://github.com/Esri/arcgis-cookbook' if respond_to?(:source_url)

--- a/cookbooks/arcgis-insights/Berksfile
+++ b/cookbooks/arcgis-insights/Berksfile
@@ -1,7 +1,5 @@
-source "https://supermarket.getchef.com"
-
-
+source 'https://supermarket.chef.io'
 
 metadata
 
-cookbook  "arcgis-enterprise", path: "../arcgis-enterprise"
+cookbook  'arcgis-enterprise', path: '../arcgis-enterprise'

--- a/cookbooks/arcgis-insights/metadata.rb
+++ b/cookbooks/arcgis-insights/metadata.rb
@@ -14,3 +14,6 @@ supports         'redhat'
 
 recipe           'arcgis-insights::default', 'Installs and configures Insights for ArcGIS'
 recipe           'arcgis-insights::uninstall', 'Uninstalls Insights for ArcGIS'
+
+issues_url 'https://github.com/Esri/arcgis-cookbook/issues' if respond_to?(:issues_url)
+source_url 'https://github.com/Esri/arcgis-cookbook' if respond_to?(:source_url)

--- a/cookbooks/arcgis-pro/Berksfile
+++ b/cookbooks/arcgis-pro/Berksfile
@@ -1,7 +1,5 @@
-source "https://supermarket.getchef.com"
-
-
+source 'https://supermarket.chef.io'
 
 metadata
 
-cookbook  "windows", "~> 1.38"
+cookbook 'windows', '~> 1.38'

--- a/cookbooks/arcgis-pro/metadata.rb
+++ b/cookbooks/arcgis-pro/metadata.rb
@@ -12,3 +12,6 @@ supports         'windows'
 
 recipe 'arcgis-pro::default', 'Installs ArcGIS Pro'
 recipe 'arcgis-pro::uninstall', 'Uninstalls ArcGIS Pro'
+
+issues_url 'https://github.com/Esri/arcgis-cookbook/issues' if respond_to?(:issues_url)
+source_url 'https://github.com/Esri/arcgis-cookbook' if respond_to?(:source_url)

--- a/cookbooks/esri-iis/Berksfile
+++ b/cookbooks/esri-iis/Berksfile
@@ -1,6 +1,4 @@
-source "https://supermarket.getchef.com"
-
-
+source 'https://supermarket.chef.io'
 
 metadata
 

--- a/cookbooks/esri-iis/metadata.rb
+++ b/cookbooks/esri-iis/metadata.rb
@@ -12,3 +12,6 @@ depends          'openssl'
 supports         'windows'
 
 recipe 'esri-iis::default', 'Enables IIS features required by ArcGIS Web Adaptor (IIS) and configures HTTPS binding.'
+
+issues_url 'https://github.com/Esri/arcgis-cookbook/issues' if respond_to?(:issues_url)
+source_url 'https://github.com/Esri/arcgis-cookbook' if respond_to?(:source_url)

--- a/cookbooks/esri-tomcat/metadata.rb
+++ b/cookbooks/esri-tomcat/metadata.rb
@@ -9,3 +9,6 @@ version '0.1.0'
 depends 'tomcat', '>= 2.3.0'
 depends 'java'
 depends 'openssl'
+
+issues_url 'https://github.com/Esri/arcgis-cookbook/issues' if respond_to?(:issues_url)
+source_url 'https://github.com/Esri/arcgis-cookbook' if respond_to?(:source_url)


### PR DESCRIPTION
Added source_url, issues_url which adds a link to relevant urls on the  public supermarket. So for example on https://supermarket.chef.io/cookbooks/esri-iis there will be a new set of buttons that will show links direct to the source code and issues on github.

Cleaned up a few rubocop issues, and updated the url to Supermarket in Berksfile

Signed-off-by: Jennifer Davis <iennae@gmail.com>