### PR TITLE
#71 Potential fix for TypeError

### DIFF
--- a/cookbooks/arcgis-enterprise/resources/portal.rb
+++ b/cookbooks/arcgis-enterprise/resources/portal.rb
@@ -33,7 +33,7 @@ attribute :content_dir, :kind_of => String
 attribute :content_store_type, :kind_of => String, :default => 'fileStore'
 attribute :content_store_provider, :kind_of => String, :default => 'FileSystem'
 attribute :content_store_connection_string, :kind_of => [String, Hash]
-attribute :object_store, :kind_of => [String, nil]
+attribute :object_store, :kind_of => String
 attribute :run_as_user, :kind_of => String
 attribute :run_as_password, :kind_of => String
 attribute :authorization_file, :kind_of => String


### PR DESCRIPTION
TypeError: class or module required
C:/opscode/chef/embedded/lib/ruby/gems/2.3.0/gems/chef-12.17.44-universal-mingw32/lib/chef/mixin/params_validate.rb:187:in `kind_of?'
...
C:/chef/local-mode-cache/cache/cookbooks/arcgis-enterprise/recipes/portal.rb:126:in `block in from_file'