### PR TITLE
Feature backups

### DIFF
--- a/cookbooks/arcgis-enterprise/attributes/backups.rb
+++ b/cookbooks/arcgis-enterprise/attributes/backups.rb
@@ -8,14 +8,3 @@ default['arcgis']['backups'].tap do |backups|
   backups['webgis_backup_configuration_file'] = ::File.join(node['arcgis']['portal']['install_dir'], "tools", "webgisdr", "Custom_webgisdr.properties")
   backups['retention_period'] = 30
 end
-
-case node['arcgis']['version']
-when '10.5'
-  default['arcgis']['python']['python_runtime_environment'] = File.join(node['arcgis']['python']['install_dir'], "ArcGISx6410.5")
-when '10.4.1'
-  default['arcgis']['python']['python_runtime_environment'] = File.join(node['arcgis']['python']['install_dir'], "ArcGISx6410.4")
-when '10.4'
-  default['arcgis']['python']['python_runtime_environment'] = File.join(node['arcgis']['python']['install_dir'], "ArcGISx6410.4")
-else
-  throw 'Unsupported ArcGIS version'
-end

--- a/cookbooks/arcgis-enterprise/attributes/backups.rb
+++ b/cookbooks/arcgis-enterprise/attributes/backups.rb
@@ -1,0 +1,21 @@
+include_attribute 'arcgis-enterprise::server'
+
+default['arcgis']['backups'].tap do |backups|
+  backups['site_url'] = 'https://' + node['arcgis']['server']['domain_name'] + '/' + node['arcgis']['server']['wa_name']
+  backups['carbon_folder'] = 'D:\\AutomatedDeployment\\AdditionalPowerShellModules\\Carbon'
+  backups['include_scene_tile_caches'] = false
+  backups['backup_restore_mode'] = 'full' # valid options: 'full' and 'incremental'
+  backups['webgis_backup_configuration_file'] = ::File.join(node['arcgis']['portal']['install_dir'], "tools", "webgisdr", "Custom_webgisdr.properties")
+  backups['retention_period'] = 30
+end
+
+case node['arcgis']['version']
+when '10.5'
+  default['arcgis']['python']['python_runtime_environment'] = File.join(node['arcgis']['python']['install_dir'], "ArcGISx6410.5")
+when '10.4.1'
+  default['arcgis']['python']['python_runtime_environment'] = File.join(node['arcgis']['python']['install_dir'], "ArcGISx6410.4")
+when '10.4'
+  default['arcgis']['python']['python_runtime_environment'] = File.join(node['arcgis']['python']['install_dir'], "ArcGISx6410.4")
+else
+  throw 'Unsupported ArcGIS version'
+end

--- a/cookbooks/arcgis-enterprise/attributes/misc.rb
+++ b/cookbooks/arcgis-enterprise/attributes/misc.rb
@@ -1,0 +1,14 @@
+include_attribute 'arcgis-enterprise::server'
+
+default['arcgis']['misc']['script_directory'] = "C:\\Chef\\scripts"
+
+case node['arcgis']['version']
+when '10.5'
+  default['arcgis']['python']['python_runtime_environment'] = File.join(node['arcgis']['python']['install_dir'], "ArcGISx6410.5")
+when '10.4.1'
+  default['arcgis']['python']['python_runtime_environment'] = File.join(node['arcgis']['python']['install_dir'], "ArcGISx6410.4")
+when '10.4'
+  default['arcgis']['python']['python_runtime_environment'] = File.join(node['arcgis']['python']['install_dir'], "ArcGISx6410.4")
+else
+  throw 'Unsupported ArcGIS version'
+end

--- a/cookbooks/arcgis-enterprise/providers/backups.rb
+++ b/cookbooks/arcgis-enterprise/providers/backups.rb
@@ -1,0 +1,74 @@
+action :authorize_user do
+  carbon_script = ::File.join(node['arcgis']['backups']['carbon_folder'], "Carbon", "Import-Carbon.ps1")
+  powershell_script "Authorize user '#{node['arcgis']['run_as_user']}' to logon as batch job" do
+    code <<-EOH
+    & #{carbon_script}
+
+    $Identity = "#{node['arcgis']['run_as_user']}"
+    $privilege = "SeBatchLogonRight"
+    Grant-Privilege -Identity $Identity -Privilege $privilege
+    EOH
+  end
+end
+
+action :create_task_server_site_backup do
+  windows_task 'ArcGIS Server Site Backup' do
+    user node['arcgis']['run_as_user']
+    password node['arcgis']['run_as_password']
+    force true
+    cwd node['arcgis']['python']['python_runtime_environment']
+    command 'python.exe "' + node['arcgis']['server']['install_dir'] + '\tools\admin\backup.py" -u ' + node['arcgis']['server']['admin_username'] + ' -p ' + node['arcgis']['server']['admin_password'] + ' -s ' + node['arcgis']['backups']['site_url'] + ' -f "' + node['arcgis']['backups']['site_backup_dir'] + '"'
+    frequency :weekly
+    frequency_modifier 1
+    day 'SAT'
+    start_time '20:00'
+    action :create
+  end
+end
+
+action :create_webgis_backup_configuration do
+  escaped_backup_path = node['arcgis']['backups']['webgis_backup_dir'].gsub('\\', '\&\&')
+  file node['arcgis']['backups']['webgis_backup_configuration_file'] do
+    content <<-EOH
+    SHARED_LOCATION=#{escaped_backup_path}
+    PORTAL_ADMIN_URL = #{node['arcgis']['portal']['url']}
+    PORTAL_ADMIN_USERNAME = #{node['arcgis']['portal']['admin_username']}
+    PORTAL_ADMIN_PASSWORD = #{node['arcgis']['portal']['admin_password']}
+    PORTAL_ADMIN_PASSWORD_ENCRYPTED = false
+    INCLUDE_SCENE_TILE_CACHES = #{node['arcgis']['backups']['include_scene_tile_caches']}
+    BACKUP_RESTORE_MODE = #{node['arcgis']['backups']['backup_restore_mode']}
+    EOH
+    rights :full_control, "#{node['arcgis']['run_as_user']}"
+    action :create
+  end
+end
+
+action :create_task_webgis_backup do
+  windows_task 'ArcGIS WebGIS Backup' do
+    user node['arcgis']['run_as_user']
+    password node['arcgis']['run_as_password']
+    force true
+    cwd ::File.join(node['arcgis']['portal']['install_dir'], "tools", "webgisdr")
+    command "webgisdr.bat --export --file #{node['arcgis']['backups']['webgis_backup_configuration_file']}"
+    frequency :weekly
+    frequency_modifier 1
+    day 'SAT'
+    start_time '21:00'
+    action :create
+  end
+end
+
+action :create_task_backup_cleanup do
+  windows_task 'Cleanup ArcGIS Backups' do
+    user node['arcgis']['run_as_user']
+    password node['arcgis']['run_as_password']
+    force true
+    cwd node['arcgis']['misc']['script_directory']
+    command "Cleanup_Backups.bat #{node['arcgis']['backups']['webgis_backup_dir']} #{node['arcgis']['backups']['retention_period']}"
+    frequency :weekly
+    frequency_modifier 1
+    day 'SAT'
+    start_time '22:00'
+    action :create
+  end
+end

--- a/cookbooks/arcgis-enterprise/recipes/backups.rb
+++ b/cookbooks/arcgis-enterprise/recipes/backups.rb
@@ -1,0 +1,23 @@
+if node['platform'] == 'windows'
+  arcgis_enterprise_backups 'Authorize backup user' do
+    action :authorize_user
+  end
+    
+  if Dir.exists? "#{node['arcgis']['portal']['install_dir']}"
+    arcgis_enterprise_backups 'Create configuration file for ArcGIS WebGIS backups' do
+      action :create_webgis_backup_configuration
+    end
+    
+    arcgis_enterprise_backups 'Create Scheduled Task for ArcGIS WebGIS backups' do
+      action :create_task_webgis_backup
+    end
+  elsif Dir.exists? "#{node['arcgis']['server']['install_dir']}"
+    arcgis_enterprise_backups 'Create Scheduled Task to backup ArcGIS Server Site' do
+      action :create_task_server_site_backup
+    end
+  end
+  
+  arcgis_enterprise_backups 'Create Scheduled Task for backup cleanup' do
+    action :create_task_backup_cleanup
+  end
+end

--- a/cookbooks/arcgis-enterprise/resources/backups.rb
+++ b/cookbooks/arcgis-enterprise/resources/backups.rb
@@ -1,0 +1,8 @@
+actions :create_task_server_site_backup, :authorize_user,
+        :create_webgis_backup_configuration, :create_task_webgis_backup,
+        :create_task_backup_cleanup
+
+def initialize(*args)
+  super
+  @action = :publish
+end

--- a/roles/webgis-windows.json
+++ b/roles/webgis-windows.json
@@ -22,6 +22,10 @@
       "keystore_file":"C:\\keystore\\mydomain_com.pfx",
       "keystore_password":"changeit"
     },
+    "backups":{
+      "site_backup_dir":"\\\\Change\\Me",
+      "webgis_backup_dir":"\\\\Change\\Me"
+    },
     "portal":{
       "admin_username":"admin",
       "admin_password":"changeit",
@@ -43,6 +47,7 @@
     "recipe[arcgis-enterprise::datastore]",
     "recipe[arcgis-enterprise::portal]",
     "recipe[arcgis-enterprise::portal_wa]",
-    "recipe[arcgis-enterprise::federation]"
+    "recipe[arcgis-enterprise::federation]",
+    "recipe[arcgis-enterprise::backups]"
   ]
 }

--- a/scripts/Cleanup_Backups.bat
+++ b/scripts/Cleanup_Backups.bat
@@ -1,0 +1,7 @@
+@echo off
+
+:: define the "\name" of a shared folder on the remote "\\device"
+:: -d -30 means that files, older than 30 days will be deleted
+PushD "%1" &&(
+  forfiles -s -m *.* -d -%2 -c "cmd /c del @file" 
+ ) & PopD


### PR DESCRIPTION
These commits enable the Cookbook to create backups of ArcGIS Server Site or the complete WebGIS (ArcGIS Server, Portal for ArcGIS, ArcGIS Data Store). It only works for Windows. There is an additional task to delete backups after a defined number of days.
The configuration is ease:

- `node['arcgis']['backups']['site_backup_dir']` --> the location where the backup of ArcGIS Server Site will be placed
- `node['arcgis']['backups']['webgis_backup_dir']` --> the location where the backup of ArcGIS Server Site will be placed

Under the hood, the code does the following:

1. Privilege the user `node['arcgis']['run_as_user']` within Windows to log on as batch job
2. If Portal is installed --> configure WebGIS-Backup-Configuration-File `<<Portal-Install-Dir>>\tools\webgisdr\Custom_webgisdr.properties`
3. If Portal for ArcGIS is installed --> create a Windows Scheduled Task to call `<<Portal-Install-Dir>>\webgisdr.bat` with the previously configured WebGIS-Backup-Configuration-File
4. If Portal is not installed, but ArcGIS Server is --> create a Windows Scheduled Task to call `<<Server-Install-Dir>>\tools\admin\backup.py` with the appropriate arguments
5. Create a Windows Scheduled Task to delete backup files if they are older than a defined number of days (`node['arcgis']['backups']['retention_period']`)

Unfortunately, I was not able to implement step 1 with either pure Ruby or Chef code. I use the additional PowerShell Module [Carbon](http://get-carbon.org/) for this - the installation of Carbon is done within a dedicated PowerShell script that I execute before Chef. 
@pbobov Maybe you find a better solution.