### PR TITLE
Set SOC Maximum Heap Size

### DIFF
--- a/cookbooks/arcgis-enterprise/libraries/server_admin_client.rb
+++ b/cookbooks/arcgis-enterprise/libraries/server_admin_client.rb
@@ -610,6 +610,48 @@ module ArcGIS
 
       validate_response(response)
     end
+    
+    def set_soc_max_heap_size(soc_max_heap_size)
+      # for updating SOC Max Heap Size, all configuration parameters (ports, etc.) have to be
+      # passed to the corresponding REST interface. Though, the current configuration is
+      # retrieved first to pass it later together with the new SOC Max Heap Size.
+      
+      token = generate_token()
+      
+      uri = URI.parse(@server_url + '/admin/local')
+      uri.query = URI.encode_www_form('token' => token,
+                                      'f' => 'json')
+
+      request = Net::HTTP::Get.new(uri.request_uri)
+      request.add_field('Referer', 'referer')
+
+      response = send_request(request, @server_url)
+
+      validate_response(response)
+      current_machine_config = JSON.parse(response.body)
+      
+      # pass the new SOC Max Heap Size and the current configuration parameters
+      # to the appropriate REST interface
+      request = Net::HTTP::Post.new(URI.parse(@server_url + '/admin/local/edit').request_uri)
+      request.add_field('Referer', 'referer')
+      request.set_form_data('machineName' => current_machine_config['machineName'],
+                            'platform' => current_machine_config['platform'],
+                            'webServerMaxHeapSize' => current_machine_config['webServerMaxHeapSize'],
+                            'appServerMaxHeapSize' => current_machine_config['appServerMaxHeapSize'],
+                            'webServerSSLEnabled' => current_machine_config['webServerSSLEnabled'],
+                            'webServerCertificateAlias' => current_machine_config['webServerCertificateAlias'],
+                            'JMXPort' => current_machine_config['ports']['JMXPort'],
+                            'OpenEJBPort' => current_machine_config['ports']['OpenEJBPort'],
+                            'NamingPort' => current_machine_config['ports']['NamingPort'],
+                            'DerbyPort' => current_machine_config['ports']['DerbyPort'],
+                            'socMaxHeapSize' => soc_max_heap_size,
+                            'token' => token, 
+                            'f' => 'json')
+
+      response = send_request(request, @server_url)
+
+      validate_response(response)
+    end
 
     private
 

--- a/cookbooks/arcgis-enterprise/providers/server.rb
+++ b/cookbooks/arcgis-enterprise/providers/server.rb
@@ -695,6 +695,25 @@ action :configure_autostart do
   end
 end
 
+action :set_soc_max_heap_size do
+  begin
+    admin_client = ArcGIS::ServerAdminClient.new(@new_resource.server_url,
+                                                 @new_resource.username,
+                                                 @new_resource.password)
+  
+    admin_client.wait_until_available
+    
+    Chef::Log.info('Setting SOC Maximum Heap Size...')
+    
+    machines = admin_client.set_soc_max_heap_size(node['arcgis']['server']['overwriteSocMaxHeapSize'])
+    
+    admin_client.wait_until_available
+  rescue Exception => e
+    Chef::Log.error "Failed to set SOC Maximum Heap Size. " + e.message
+    raise e
+  end
+end
+
 private
 
 def generate_admin_token(install_dir, expiration)

--- a/cookbooks/arcgis-enterprise/recipes/server_machines.rb
+++ b/cookbooks/arcgis-enterprise/recipes/server_machines.rb
@@ -1,0 +1,9 @@
+unless node['arcgis']['server']['overwriteSocMaxHeapSize'].nil?
+  arcgis_enterprise_server 'Set SOC Maximum Heap Size' do
+    server_url node['arcgis']['server']['url']
+    username node['arcgis']['server']['admin_username']
+    password node['arcgis']['server']['admin_password']
+    only_if { node['arcgis']['server']['overwriteSocMaxHeapSize'] }
+    action :set_soc_max_heap_size
+  end
+end

--- a/cookbooks/arcgis-enterprise/resources/server.rb
+++ b/cookbooks/arcgis-enterprise/resources/server.rb
@@ -19,7 +19,8 @@
 
 actions :system, :unpack, :install, :uninstall, :update_account, :stop, :start,
         :configure_autostart, :authorize, :create_site, :join_site,
-        :join_cluster, :configure_https, :register_database, :federate
+        :join_cluster, :configure_https, :register_database, :federate,
+        :set_soc_max_heap_size
 
 attribute :setup_archive, :kind_of => String
 attribute :setups_repo, :kind_of => String

--- a/roles/webgis-windows.json
+++ b/roles/webgis-windows.json
@@ -20,7 +20,8 @@
       "setup":"C:\\ArcGIS\\10.5\\Server\\Setup.exe",
       "authorization_file":"C:\\ArcGIS\\10.5\\Authorization_Files\\Server.prvc",
       "keystore_file":"C:\\keystore\\mydomain_com.pfx",
-      "keystore_password":"changeit"
+      "keystore_password":"changeit",
+      "overwriteSocMaxHeapSize":256
     },
     "portal":{
       "admin_username":"admin",
@@ -40,6 +41,7 @@
     "recipe[esri-iis]",
     "recipe[arcgis-enterprise::server]",
     "recipe[arcgis-enterprise::server_wa]",
+    "recipe[arcgis-enterprise::server_machines]",
     "recipe[arcgis-enterprise::datastore]",
     "recipe[arcgis-enterprise::portal]",
     "recipe[arcgis-enterprise::portal_wa]",


### PR DESCRIPTION
With the help of this commit, you can set ArcGIS Server's property 'Maximum SOC Heap Size'. This is useful for geoprocessing, some 3rd party tools like WebOffice even enforce you to configure this.
You only have to set the parameter `node['arcgis']['overwriteSocMaxHeapSize']`.