### PR TITLE
Install ArcGIS Patches

### DIFF
--- a/cookbooks/arcgis-enterprise/providers/patches.rb
+++ b/cookbooks/arcgis-enterprise/providers/patches.rb
@@ -1,0 +1,18 @@
+action :install do
+  # Dir.glob() doesn't support backslashes within a path, so they will be replaces on Windows
+  if node['platform'] == 'windows'
+    patch_folder = node["arcgis"]["patches"]["local_patch_folder"].gsub('\\','/')
+  else
+    patch_folder = node["arcgis"]["patches"]["local_patch_folder"]
+  end
+
+  # get all patches  within the specified folder and register them
+  Dir.glob("#{patch_folder}/**/*").each do |patch|
+    windows_package "Install #{patch}" do
+      action :install
+      source patch
+      installer_type :custom
+      options '/qn'
+    end
+  end
+end

--- a/cookbooks/arcgis-enterprise/recipes/patches.rb
+++ b/cookbooks/arcgis-enterprise/recipes/patches.rb
@@ -1,0 +1,4 @@
+arcgis_enterprise_patches 'Install ArcGIS Patches' do
+  only_if { !node['arcgis']['server']['product_code'].nil? }
+  action :install
+end

--- a/cookbooks/arcgis-enterprise/resources/patches.rb
+++ b/cookbooks/arcgis-enterprise/resources/patches.rb
@@ -1,0 +1,6 @@
+actions :install
+
+def initialize(*args)
+  super
+  @action = :publish
+end

--- a/roles/webgis-windows.json
+++ b/roles/webgis-windows.json
@@ -22,6 +22,9 @@
       "keystore_file":"C:\\keystore\\mydomain_com.pfx",
       "keystore_password":"changeit"
     },
+    "patches":{
+      "local_patch_folder":"D:\\AutomatedDeployment\\ArcGIS\\Patches"
+    },
     "portal":{
       "admin_username":"admin",
       "admin_password":"changeit",
@@ -43,6 +46,7 @@
     "recipe[arcgis-enterprise::datastore]",
     "recipe[arcgis-enterprise::portal]",
     "recipe[arcgis-enterprise::portal_wa]",
-    "recipe[arcgis-enterprise::federation]"
+    "recipe[arcgis-enterprise::federation]",
+    "recipe[arcgis-enterprise::patches]"
   ]
 }


### PR DESCRIPTION
This commit enables you to install ArcGIS Patches (*.MSP files) from a local folder on the node. In theory, it would also work with remote files, but very often Windows does not allow you to install MSP files from a remote destination without prompting the user.
The local path can be configured with `node['arcgis']['patches']['local_patch_folder']`.