### PR TITLE
Provide the ability to maintain data sources

### DIFF
--- a/cookbooks/arcgis-enterprise/attributes/datasources.rb
+++ b/cookbooks/arcgis-enterprise/attributes/datasources.rb
@@ -1,0 +1,6 @@
+include_attribute 'arcgis-enterprise::misc'
+
+default['arcgis']['datasources'].tap do |datasource|
+  datasource['block_data_copy'] = false
+  datasource['ags_connection_file'] = File.join(node['arcgis']['misc']['script_directory'], 'AdminConnection.ags')
+end

--- a/cookbooks/arcgis-enterprise/attributes/misc.rb
+++ b/cookbooks/arcgis-enterprise/attributes/misc.rb
@@ -1,0 +1,14 @@
+include_attribute 'arcgis-enterprise::server'
+
+default['arcgis']['misc']['script_directory'] = "C:\\Chef\\scripts"
+
+case node['arcgis']['version']
+when '10.5'
+  default['arcgis']['python']['python_runtime_environment'] = File.join(node['arcgis']['python']['install_dir'], "ArcGISx6410.5")
+when '10.4.1'
+  default['arcgis']['python']['python_runtime_environment'] = File.join(node['arcgis']['python']['install_dir'], "ArcGISx6410.4")
+when '10.4'
+  default['arcgis']['python']['python_runtime_environment'] = File.join(node['arcgis']['python']['install_dir'], "ArcGISx6410.4")
+else
+  throw 'Unsupported ArcGIS version'
+end

--- a/cookbooks/arcgis-enterprise/libraries/server_admin_client.rb
+++ b/cookbooks/arcgis-enterprise/libraries/server_admin_client.rb
@@ -611,6 +611,26 @@ module ArcGIS
       validate_response(response)
     end
 
+    def block_data_copy()
+      request = Net::HTTP::Post.new(URI.parse(@server_url + '/admin/data/config/update').request_uri)
+      
+      request.add_field('Referer', 'referer')
+      
+      token = generate_token()
+      
+      dataStoreConfig = {
+        'blockDataCopy' => true
+      }
+      
+      request.set_form_data('datastoreConfig' => dataStoreConfig.to_json,
+                            'token' => token, 
+                            'f' => 'json')
+
+      response = send_request(request, @server_url)
+
+      validate_response(response)
+    end
+    
     private
 
     def send_request(request, url)

--- a/cookbooks/arcgis-enterprise/providers/datasources.rb
+++ b/cookbooks/arcgis-enterprise/providers/datasources.rb
@@ -1,0 +1,206 @@
+action :create_ags_connection_file do
+  server_url = get_server_url
+  username = @new_resource.admin_user
+  password = @new_resource.admin_password
+  out_dir = ::File.dirname(node['arcgis']['datasources']['ags_connection_file'])
+  ags_connection_file_name = ::File.basename(node['arcgis']['datasources']['ags_connection_file'])
+
+  # create an ArcGIS Server Connection file which is needed for the following registration process
+  python_script_file = ::File.join(node['arcgis']['misc']['script_directory'], 'CreateGISServerConnectionFile.py')
+  execute 'Create ArcGIS Server Connection File' do
+    cwd node['arcgis']['python']['python_runtime_environment']
+    command "python #{python_script_file} #{server_url} #{username} #{password} #{out_dir} #{ags_connection_file_name}"
+  end
+end
+
+action :create_folder do
+  folder = @new_resource.folder
+  
+  unless folder['security_permissions']['full_control_members'].nil?
+    folder['security_permissions']['full_control_members'].each do |full_control_member|
+      directory folder['server_path'] do
+        rights :full_control, full_control_member, :applies_to_children => true
+        action :create
+      end
+    end
+  end
+  
+  if @new_resource.authorize_arcgis_service_account == true
+    directory folder['server_path'] do
+      rights :full_control, node['arcgis']['run_as_user'], :applies_to_children => true
+      action :create
+    end
+  end
+end
+
+action :share_folder do
+  folder = @new_resource.folder
+  share_name = folder['share_name']
+      
+  # the following PowerShell commands for creating shares expect the members in a comma-separated format
+  concatenated_members = folder['sharing_permissions']['full_control_members'].join(""",""")
+  concatenated_members = """" + concatenated_members + """"
+  
+  # To share the previously created directories, a PowerShell script has to be executed.
+  # The script checks whether the share exists, creates it when absent or
+  # recreates it when existing
+  powershell_script "Share directory #{share_name}" do
+    code <<-EOH
+    # the SMBShare-Cmdlet was introduced with Windows Server 2012. Due to this circumstance, the ELSE-Branch contains
+    # the former, more elaborate way of creating shares to support older versions of Windows Server (e. g. 2008).
+    if (Get-Command "Get-SMBShare" -errorAction SilentlyContinue) {
+      # delete old share if it exists
+      if (Get-SMBShare -Name "#{share_name}" -ea 0) {
+        Remove-SmbShare -Name "#{share_name}" -Force
+      }
+      New-SMBShare -Name "#{share_name}" -Path "#{folder['server_path']}" -FullAccess #{concatenated_members}
+    }
+    else {
+      # delete old share if it exists
+      if ($share = Get-WmiObject -Class Win32_Share -Filter "Name='#{share_name}'") {
+        $share.delete()
+      }
+  
+      # split the comma-separated accounts into a PowerShell array
+      $FullyQualifiedDomainUsers = "#{concatenated_members}".split(",")
+
+      # SecurityDescriptor containting access
+      $sd = ([wmiclass]'Win32_SecurityDescriptor').psbase.CreateInstance()
+      $sd.ControlFlags = 4
+
+      $aces = New-Object System.Collections.ArrayList
+      ForEach($FullyQualifiedDomainUser in $FullyQualifiedDomainUsers) {
+        # distinguish between domain and non-domain accounts
+        $splittedStrings = $FullyQualifiedDomainUser.Split("\\")
+        if ($splittedStrings.length -eq 1) {
+          $Domain = $Null
+          $User = $FullyQualifiedDomainUser
+        }
+        elseif ($splittedStrings.length -eq 2) {
+          $Domain = $splittedStrings[0]
+          $User = $splittedStrings[1]
+        }
+        else {
+          throw "Format of provided user '$FullyQualifiedDomainUser' is not supported. The string must only contain one backslash."
+        }
+        
+        # Username/Group to give permissions to
+        $trustee = ([wmiclass]'Win32_trustee').psbase.CreateInstance()
+        $trustee.Domain = $Domain
+        $trustee.Name = $User
+
+        # Accessmask values
+        $fullcontrol = 2032127
+
+        # Create access-list
+        $ace = ([wmiclass]'Win32_ACE').psbase.CreateInstance()
+        $ace.AccessMask = $fullcontrol
+        $ace.AceFlags = 3
+        $ace.AceType = 0
+        $ace.Trustee = $trustee
+
+        # add current account to list off all accounts that should get permissions
+        $aces.Add($ace) > $null
+      }
+
+      $sd.DACL = $aces
+
+      $Shares=[WMICLASS]"WIN32_Share"
+      $retObj = $Shares.Create("#{folder['server_path']}", "#{share_name}", 0, 20, "", "", $sd)
+      Exit $retObj.ReturnValue
+    }
+    EOH
+  end
+end
+
+action :register_folder do
+  folder = @new_resource.folder
+  folder_identifier = folder['publish_folder']['identifier']
+      
+  if @new_resource.publish_with_hostname == true
+    publisher_path = "\\\\" + ENV['COMPUTERNAME'] + "\\" + folder['share_name']
+    command_arguments = "#{folder_identifier} #{folder['server_path']} #{publisher_path}"
+  end
+  
+  if @new_resource.publish_with_fqdn == true
+    publisher_path = "\\\\" + node['fqdn'] + "\\" + folder['share_name']
+    command_arguments = "#{folder_identifier} #{folder['server_path']} #{publisher_path}"
+  end
+  
+  if @new_resource.publish_with_alternative_path == true
+    # ArcGIS Server allows to use different folders for publishing and on the server 
+    # => this can be set here
+    publisher_path = folder['publish_folder']['publish_alternative_path']
+    if folder['server_path'].nil?
+      command_arguments = "#{folder_identifier} #{publisher_path}"
+    else
+      command_arguments = "#{folder_identifier} #{folder['server_path']} #{publisher_path}"
+    end
+  end
+  
+  python_script_file = ::File.join(node['arcgis']['misc']['script_directory'], 'RegisterFolderAsDatasource.py')
+  execute "Register folder #{folder_identifier} as datasource" do
+    cwd node['arcgis']['python']['python_runtime_environment']
+    command "python #{python_script_file} #{node['arcgis']['datasources']['ags_connection_file']} #{command_arguments}"
+  end
+end
+
+action :register_sde_files do
+  # Dir.glob() doesn't support backslashes within a path, so they will be replaces on Windows
+  if node['platform'] == 'windows'
+    folder = node['arcgis']['datasources']['sde_files']['folder'].gsub('\\','/')
+  else
+    folder = node['arcgis']['datasources']['sde_files']['folder']
+  end
+
+  # get all SDE files within the specified folder and register them
+  Dir.glob("#{folder}/**/*.sde") do |sde_file|
+    register_sde_file(sde_file)
+  end
+end
+
+action :register_sde_files_from_folder do
+  # iterate over all specified SDE files and register them
+  node['arcgis']['datasources']['sde_files']['files'].each do |sde_file|
+    register_sde_file(sde_file)
+  end
+end
+
+action :delete_ags_connection_file do
+  file node['arcgis']['datasources']['ags_connection_file'] do
+    action :delete
+  end
+end
+
+private
+
+def register_sde_file(sde_file)
+  sde_name = ::File.basename(sde_file, ".*")
+  python_script_file = ::File.join(node['arcgis']['misc']['script_directory'], 'RegisterSdeFileAsDatasource.py')
+  execute "Register SDE #{sde_name} as datasource" do
+    cwd node['arcgis']['python']['python_runtime_environment']
+    command "python #{python_script_file} #{node['arcgis']['datasources']['ags_connection_file']} #{sde_name} #{sde_file}"
+  end
+end
+
+def get_server_url
+  # retrieve URL to configure ArcGIS Server via HTTPS:
+  # 1. Check whether a dedicated parameter has been specified
+  # 2. Read the SSL certificate and construct the URL out of the certificat's subject name
+  # 3. Use existing Cookbook parameter as fallback (high chance that this results in certificate errors)
+  if !node['arcgis']['datasources']['server_config_url'].nil?
+    server_url = node['arcgis']['datasources']['server_config_url'] + "/admin"
+  else
+    if ::File.exist?(node['arcgis']['server']['keystore_file'])
+      p12 = OpenSSL::PKCS12.new(::File.binread(node['arcgis']['server']['keystore_file']), node['arcgis']['server']['keystore_password'])
+      cert = p12.certificate
+      cert_cn = cert.subject.to_a.select{|name, _, _| name == 'CN' }.first[1]
+      
+      server_url = 'https://' + cert_cn + ":6443/arcgis/admin"
+    else
+      server_url = node['arcgis']['server']['url'] + "/admin"
+    end
+  end
+  
+  server_url
+end

--- a/cookbooks/arcgis-enterprise/recipes/datasources.rb
+++ b/cookbooks/arcgis-enterprise/recipes/datasources.rb
@@ -1,0 +1,107 @@
+arcgis_enterprise_datasources 'Create ArcGIS Server connection file' do
+  admin_user node['arcgis']['server']['admin_username']
+  admin_password node['arcgis']['server']['admin_password']
+  action :create_ags_connection_file
+end
+
+# register folders
+if !node['arcgis']['datasources']['folders'].nil?
+  node['arcgis']['datasources']['folders'].each do |folder|
+    # retrieve strategy regarding folder creation, security, sharing and publishing of the current folder
+    if folder['create_folder'].nil? || folder['create_folder'] == false
+      create_folder = false
+    else
+      create_folder = true
+      
+      # should the Windows Service Account of ArcGIS Server be authorized?
+      if folder['security_permissions']['authorize_arcgis_service_account'].nil? || folder['security_permissions']['authorize_arcgis_service_account'] == false
+        authorize_arcgis_service_account = false
+      else
+        authorize_arcgis_service_account = true
+      end
+    end
+    
+    if folder['share_folder'].nil? || folder['share_folder'] == false
+      share_folder = false
+    else
+      share_folder = true
+    end
+    
+    # should the folder be registered within ArcGIS Server?
+    if folder['publish_folder'].nil?
+      publish_folder = false
+    else
+      publish_folder = true
+      
+      # should the folder be registered with it's hostname?
+      if folder['publish_folder']['publish_with_hostname'].nil? || folder['publish_folder']['publish_with_hostname'] == false
+        publish_with_hostname = false
+      else
+        publish_with_hostname = true
+      end
+      
+      # should the folder be registered with it's fully qualified domain name?
+      if folder['publish_folder']['publish_with_fqdn'].nil? || folder['publish_folder']['publish_with_fqdn'] == false
+        publish_with_fqdn = false
+      else
+        publish_with_fqdn = true
+      end
+      
+      # should the folder be registered with an alternative path?
+      if folder['publish_folder']['publish_alternative_path'].nil? || folder['publish_folder']['publish_alternative_path'] == false
+        publish_with_alternative_path = false
+      else
+        publish_with_alternative_path = true
+      end
+    end
+    
+    # create/update folder and set privileges for the configured members
+    arcgis_enterprise_datasources "Create folder #{folder['server_path']}" do
+      authorize_arcgis_service_account authorize_arcgis_service_account
+      folder folder
+      only_if { create_folder }
+      action :create_folder
+    end
+    
+    arcgis_enterprise_datasources "Share folder #{folder['server_path']}" do
+      folder folder
+      only_if { share_folder }
+      action :share_folder
+    end
+       
+    # register folder within ArcGIS Server
+    arcgis_enterprise_datasources "Register folder #{folder['server_path']} in ArcGIS Server" do
+      folder folder
+      publish_with_hostname publish_with_hostname
+      publish_with_fqdn publish_with_fqdn
+      publish_with_alternative_path publish_with_alternative_path
+      only_if { publish_folder }
+      action :register_folder
+    end
+  end
+end
+
+# register SDE connections
+if !node['arcgis']['datasources']['sde_files'].nil?
+  arcgis_enterprise_datasources 'Register SDE files from folder as data source within ArcGIS Server' do
+    not_if { node['arcgis']['datasources']['sde_files']['folder'].nil? }
+    action :register_sde_files_from_folder
+  end
+  
+  arcgis_enterprise_datasources 'Register SDE files as data source within ArcGIS Server' do
+    not_if { node['arcgis']['datasources']['sde_files']['files'].nil? }
+    action :register_sde_files
+  end
+end
+
+arcgis_enterprise_datasources 'Delete ArcGIS Server connection file' do
+  action :delete_ags_connection_file
+end
+
+arcgis_enterprise_server 'Block the automatic copying of data to the server at publish time' do
+  server_url node['arcgis']['server']['url']
+  username node['arcgis']['server']['admin_username']
+  password node['arcgis']['server']['admin_password']
+  only_if { node['arcgis']['datasources']['block_data_copy'] }
+  action :block_data_copy
+end

--- a/cookbooks/arcgis-enterprise/resources/datasources.rb
+++ b/cookbooks/arcgis-enterprise/resources/datasources.rb
@@ -1,0 +1,16 @@
+actions :create_ags_connection_file, :delete_ags_connection_file,
+        :create_folder, :share_folder, :register_folder,
+        :register_sde_files, :register_sde_files_from_folder
+
+attribute :admin_user, :kind_of => String
+attribute :admin_password, :kind_of => String
+attribute :folder, :kind_of => Hash
+attribute :authorize_arcgis_service_account, :kind_of => [TrueClass, FalseClass], :default => false
+attribute :publish_with_alternative_path, :kind_of => [TrueClass, FalseClass], :default => false
+attribute :publish_with_fqdn, :kind_of => [TrueClass, FalseClass], :default => false
+attribute :publish_with_hostname, :kind_of => [TrueClass, FalseClass], :default => false
+        
+def initialize(*args)
+  super
+  @action = :publish
+end

--- a/roles/webgis-windows.json
+++ b/roles/webgis-windows.json
@@ -22,6 +22,58 @@
       "keystore_file":"C:\\keystore\\mydomain_com.pfx",
       "keystore_password":"changeit"
     },
+    "datasources":{
+      "block_data_copy":true,
+      "folders":[
+        {
+          "server_path":"D:\\Mapfiles",
+          "create_folder":true,
+          "security_permissions":{
+            "authorize_arcgis_service_account":true
+          },
+          "share_folder":true,
+          "share_name":"Mapfiles",
+          "sharing_permissions":{
+            "full_control_members":["MyDomain\\MyUser", "MyDomain\\MyGroup"]
+          },
+          "publish_folder":{
+            "identifier":"Mapfiles",
+            "publish_with_hostname":true
+          }
+        },{
+          "server_path":"D:\\Data",
+          "create_folder":true,
+          "security_permissions":{
+            "authorize_arcgis_service_account":true,
+            "full_control_members":["MyDomain\\MyUser", "MyDomain\\MyGroup"]
+          },
+          "share_folder":true,
+          "share_name":"Data",
+          "sharing_permissions":{
+            "full_control_members":["MyDomain\\MyUser", "MyDomain\\MyGroup"]
+          },
+          "publish_folder":{
+            "identifier":"Data",
+            "publish_with_hostname":true
+          }
+        },{
+          "server_path":"D:\\Data",
+          "publish_folder":{
+            "identifier":"Data_With_Alias",
+            "publish_alternative_path":"\\\\<<DNS-Alias>>\\Data"
+          }
+        },{
+          "publish_folder":{
+            "identifier":"OtherData",
+            "publish_alternative_path":"\\\\Path\\To\\Other\\Data"
+          }
+        }
+      ],
+      "sde_files":{
+        "folder":"\\\\Folder\\With\\SDE\\Files",
+        "files":["\\\\AnotherFolder\\With\\SDE\\Files\\File1.sde", "\\\\AnotherFolder\\With\\SDE\\Files\\File2.sde"]
+      }
+    },
     "portal":{
       "admin_username":"admin",
       "admin_password":"changeit",
@@ -40,6 +92,7 @@
     "recipe[esri-iis]",
     "recipe[arcgis-enterprise::server]",
     "recipe[arcgis-enterprise::server_wa]",
+    "recipe[arcgis-enterprise::datasources]",
     "recipe[arcgis-enterprise::datastore]",
     "recipe[arcgis-enterprise::portal]",
     "recipe[arcgis-enterprise::portal_wa]",

--- a/scripts/CreateGISServerConnectionFile.py
+++ b/scripts/CreateGISServerConnectionFile.py
@@ -1,0 +1,26 @@
+import arcpy, os, sys
+
+server_url = sys.argv[1]
+username = sys.argv[2]
+password = sys.argv[3]
+out_dir = sys.argv[4]
+out_name = sys.argv[5]
+out_folder_path = out_dir
+out_full_path = os.path.join(out_dir, out_name)
+staging_folder_path = out_dir
+use_arcgis_desktop_staging_folder = False
+
+# Check if connection file already exists => if yes, delete it
+if os.path.exists(out_full_path):
+    os.remove(out_full_path)
+
+arcpy.mapping.CreateGISServerConnectionFile("ADMINISTER_GIS_SERVICES",
+    out_folder_path,
+    out_name,
+    server_url,
+    "ARCGIS_SERVER",
+    use_arcgis_desktop_staging_folder,
+    staging_folder_path,
+    username,
+    password,
+    "SAVE_USERNAME")

--- a/scripts/RegisterFolderAsDatasource.py
+++ b/scripts/RegisterFolderAsDatasource.py
@@ -1,0 +1,22 @@
+import arcpy
+
+conn = sys.argv[1]
+name = sys.argv[2]
+server_path = sys.argv[3]
+
+# check whether an additional publisher path has been provided
+if (len(sys.argv) > 4):
+    publisher_path = sys.argv[4]
+else:
+	publisher_path = ""
+
+# check whether the folder to register is already register => if yes, delete the former registered folders
+for item in arcpy.ListDataStoreItems(conn, "FOLDER"):
+    current_name = item[0]
+    if current_name == name:
+        arcpy.RemoveDataStoreItem(conn, "FOLDER", name)
+
+if  publisher_path == "":
+    arcpy.AddDataStoreItem(conn, "FOLDER", name, server_path)
+else:
+    arcpy.AddDataStoreItem(conn, "FOLDER", name, server_path, publisher_path)

--- a/scripts/RegisterSdeFileAsDatasource.py
+++ b/scripts/RegisterSdeFileAsDatasource.py
@@ -1,0 +1,13 @@
+import arcpy
+
+conn = sys.argv[1]
+name = sys.argv[2]
+sde_file = sys.argv[3]
+
+# check whether the SDE to register is already register => if yes, delete the former registered SDE
+for item in arcpy.ListDataStoreItems(conn, "DATABASE"):
+    current_name = item[0]
+    if current_name == name:
+        arcpy.RemoveDataStoreItem(conn, "DATABASE", name)
+
+arcpy.AddDataStoreItem(conn, "DATABASE", name, sde_file)


### PR DESCRIPTION
This commit enables you to:

- create local folders in the Node's file system
- create Windows network shares
- register a folder as an ArcGIS Server's data source --> you can even set different publisher and server paths
- register either a folder with SDE connection files or an array of SDE connection files as ArcGIS Server data sources
- block the copying of data to ArcGIS Server when publishing content

Within `webgis-windows.json`, you can configure the following:

- `node['arcgis']['datasources']['block_data_copy']` --> `true` or `false`, default is `false`
- `node['arcgis']['datasources']['folders']` --> an array of folders. The description of a `folder`-object follows after this list.
- `node['arcgis']['datasources']['sde_files']['folder']` --> all SDE connection files within this folder will be imported into ArcGIS Server as an enterprise data source
- `node['arcgis']['datasources']['sde_files']['files']` --> an array of SDE connection files. All of them will be imported into ArcGIS Server as an enterprise data source

A `folder`-object looks like this:

- `folder['server_path']` --> local path on the Node
- `folder['create_folder']` --> `true` or `false` to indicate whether to create `folder['server_path']` or not. Default is `false`
- `folder['security_permissions']['full_control_members']` --> an array of accounts (even Active Directory members) that will be privileged with full control permissions to the created folder
- `folder['security_permissions']['authorize_arcgis_service_account']` --> `true` or `false` to indicate whether the account `node['arcgis']['run_as_user']` should be privileged with full control permissions to the created folder. Default is `false`
- `folder['share_folder']` --> `true` or `false` to indicate whether to share `folder['server_path']` or not. Default is `false`
- `folder['share_name']` --> Name of the Windows share. This parameter is mandatory when setting `folder['share_folder']` to `true`
- `folder['sharing_permissions']['full_control_members']` --> an array of accounts (even Active Directory members) that will be privileged with full control permissions to the shared folder
- `folder['publish_folder']['publish_with_hostname']` --> `true` or `false` to indicate whether `folder['server_path']` will be registered as an ArcGIS Server folder data source according the scheme: Publisher Path --> `\\<Hostname>\folder['share_name']` | Server Path --> `folder['server_path']`. Default is `false`
- `folder['publish_folder']['publish_with_fqdn']` --> `true` or `false` to indicate whether `folder['server_path']` will be registered as an ArcGIS Server folder data source according the scheme: Publisher Path --> `\\<Fully Qualified Domain Name>\folder['share_name']` | Server Path --> `folder['server_path']`. Default is `false`
- `folder['publish_folder']['publish_alternative_path']` --> a directory that will beregistered as an ArcGIS Server folder data source according the scheme: Publisher Path --> `folder['publish_folder']['publish_alternative_path']` | Server Path --> `folder['server_path']` or the ArcGIS Server Property 'Use same as Publisher Path' will be used when `folder['server_path']` is let empty