### PR TITLE
Updates Ubuntu Role from Java 7 to Java 8.

### DIFF
--- a/roles/webgis-ubuntu.json
+++ b/roles/webgis-ubuntu.json
@@ -1,7 +1,7 @@
 {
   "java":{
     "install_flavor":"oracle",
-    "jdk_version":"7",
+    "jdk_version":"8",
     "oracle":{
       "accept_oracle_download_terms":true
     }


### PR DESCRIPTION
The Java 7 installer is not available for programmatic download using the supplied Java cookbook. This upgrades the role to use Java 8, as the RHEL role already had been.