### PR TITLE
Adds Missing Web Adaptor Tomcat configuration to Ubuntu role.

### DIFF
--- a/roles/webgis-ubuntu.json
+++ b/roles/webgis-ubuntu.json
@@ -6,6 +6,9 @@
       "accept_oracle_download_terms":true
     }
   },
+  "tomcat":{
+    "instance_name":"arcgis"
+  },
   "arcgis":{
     "run_as_user":"arcgis",
     "version":"10.5",
@@ -43,6 +46,7 @@
   "run_list":[
     "recipe[arcgis-enterprise::system]",
     "recipe[java]",
+    "recipe[esri-tomcat]",
     "recipe[iptables]",
     "recipe[arcgis-enterprise::iptables]",
     "recipe[arcgis-enterprise::server]",


### PR DESCRIPTION
The supplied role for Ubuntu has the effect of trying to install Web Adapter with no Tomcat. This causes the converge process to freeze for several minutes before finally dying. This ports the necessary tomcat config from the RHEL role.