### PR TITLE
Add Portal security recipe

### DIFF
--- a/cookbooks/arcgis-enterprise/attributes/portal.rb
+++ b/cookbooks/arcgis-enterprise/attributes/portal.rb
@@ -70,6 +70,9 @@ default['arcgis']['portal'].tap do |portal|
 
   # authorization_file_version must be <major>.<minor> ('10.4.1' -> '10.4')
   portal['authorization_file_version'] = node['arcgis']['version'].to_f.to_s
+  
+  portal['security']['user_store_config'] = {'type' => 'BUILTIN', 'properties' => {}}
+  portal['security']['role_store_config'] = {'type' => 'BUILTIN', 'properties' => {}}
 
   portal['log_level'] = 'WARNING'
   portal['max_log_file_age'] = 90

--- a/cookbooks/arcgis-enterprise/libraries/portal_admin_client.rb
+++ b/cookbooks/arcgis-enterprise/libraries/portal_admin_client.rb
@@ -532,6 +532,23 @@ module ArcGIS
       validate_response(response)
     end
 
+    def set_identity_store(user_store_config, role_store_config)
+      request = Net::HTTP::Post.new(URI.parse(@portal_url + '/portaladmin/security/config/updateIdentityStore').request_uri)
+
+      request.add_field('Referer', 'referer')
+
+      token = generate_token(@portal_url + '/sharing/generateToken')
+
+      request.set_form_data('userStoreConfig' => user_store_config.to_json,
+                            'groupStoreConfig' => role_store_config.to_json,
+                            'token' => token,
+                            'f' => 'json')
+
+      response = send_request(request)
+
+      validate_response(response)
+    end		
+	
     def add_root_cert(cert_location, cert_alias, norestart)
       begin
         require 'net/http/post/multipart'

--- a/cookbooks/arcgis-enterprise/providers/portal.rb
+++ b/cookbooks/arcgis-enterprise/providers/portal.rb
@@ -394,7 +394,7 @@ end
 
 action :set_identity_store do
   begin
-    portal_admin_client= ArcGIS::PortalAdminClient.new(@new_resource.server_url,
+    portal_admin_client= ArcGIS::PortalAdminClient.new(@new_resource.portal_url,
                                                  @new_resource.username,
                                                  @new_resource.password)
 

--- a/cookbooks/arcgis-enterprise/providers/portal.rb
+++ b/cookbooks/arcgis-enterprise/providers/portal.rb
@@ -392,6 +392,27 @@ action :join_site do
   end
 end
 
+action :set_identity_store do
+  begin
+    portal_admin_client= ArcGIS::PortalAdminClient.new(@new_resource.server_url,
+                                                 @new_resource.username,
+                                                 @new_resource.password)
+
+    portal_admin_client.wait_until_available
+
+    Chef::Log.info('Setting Portal identity stores...')
+
+    portal_admin_client.set_identity_store(@new_resource.user_store_config,@new_resource.role_store_config)
+
+    portal_admin_client.wait_until_available
+
+    new_resource.updated_by_last_action(true)
+  rescue Exception => e
+    Chef::Log.error "Failed to configure Portal identity stores. " + e.message
+    raise e
+  end
+end
+
 action :unregister_standby do
   portal_admin_client = ArcGIS::PortalAdminClient.new(
     @new_resource.portal_url,

--- a/cookbooks/arcgis-enterprise/recipes/portal_security.rb
+++ b/cookbooks/arcgis-enterprise/recipes/portal_security.rb
@@ -1,0 +1,26 @@
+#
+# Cookbook Name:: arcgis-enterprise
+# Recipe:: portal_security
+#
+# Copyright 2018 Esri
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+arcgis_enterprise_portal 'Configure Portal identity store' do
+  server_url node['arcgis']['portal']['url']
+  username node['arcgis']['portal']['admin_username']
+  password node['arcgis']['portal']['admin_password']
+  user_store_config node['arcgis']['portal']['security']['user_store_config']
+  role_store_config node['arcgis']['portal']['security']['role_store_config']
+  action :set_identity_store
+end

--- a/cookbooks/arcgis-enterprise/recipes/portal_security.rb
+++ b/cookbooks/arcgis-enterprise/recipes/portal_security.rb
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 arcgis_enterprise_portal 'Configure Portal identity store' do
-  server_url node['arcgis']['portal']['url']
+  portal_url node['arcgis']['portal']['url']
   username node['arcgis']['portal']['admin_username']
   password node['arcgis']['portal']['admin_password']
   user_store_config node['arcgis']['portal']['security']['user_store_config']

--- a/cookbooks/arcgis-enterprise/resources/portal.rb
+++ b/cookbooks/arcgis-enterprise/resources/portal.rb
@@ -21,7 +21,7 @@ actions :system, :unpack, :install, :uninstall, :stop, :start,
         :update_account, :configure_autostart, :authorize,
         :create_site, :join_site, :configure_https,
         :unregister_standby, :register_server, :federate_server,
-        :enable_geoanalytics, :disable_geoanalytics
+        :set_identity_store, :enable_geoanalytics, :disable_geoanalytics
 
 attribute :setup_archive, :kind_of => String
 attribute :setups_repo, :kind_of => String
@@ -66,6 +66,8 @@ attribute :log_dir, :kind_of => String
 attribute :max_log_file_age, :kind_of => Integer, :default => 90
 attribute :upgrade_backup, :kind_of => [TrueClass, FalseClass], :default => true
 attribute :upgrade_rollback, :kind_of => [TrueClass, FalseClass], :default => true
+attribute :user_store_config, :kind_of => Hash, :default => {}
+attribute :role_store_config, :kind_of => Hash, :default => {}													  
 
 def initialize(*args)
   super

--- a/roles/portal-windows-security.json
+++ b/roles/portal-windows-security.json
@@ -1,0 +1,42 @@
+{
+  "arcgis":{
+    "run_as_password":"Run_As_Pa$$w0rd",
+    "run_as_user":"arcgis",
+    "version":"10.5",
+    "portal":{
+      "admin_username":"admin",
+      "admin_password":"changeit",
+      "admin_email":"admin@mydomain.com",
+      "security_question":"Your favorite ice cream flavor?",
+      "security_question_answer":"vanilla",
+      "content_dir":"C:\\arcgisportal\\content",
+      "setup":"C:\\ArcGIS\\10.5\\Portal\\Setup.exe",
+      "authorization_file":"C:\\ArcGIS\\10.5\\Authorization_Files\\Portal.prvc",
+      "keystore_file":"C:\\keystore\\mydomain_com.pfx",
+      "keystore_password":"changeit",
+      "security": {
+        "user_store_config": {
+          "type": "WINDOWS", 
+          "properties": {
+			"userPassword": "changeit",
+			"isPasswordEncrypted": "false",
+			"user": "DOMAIN\\user",
+			"userFullnameAttribute": "cn",
+			"userEmailAttribute": "mail",
+			"caseSensitive": "false"
+          }
+        },
+        "role_store_config": {
+          "type": "WINDOWS", 
+          "properties": {
+            "user": "DOMAIN\\user",
+            "userPassword": "changeit"
+          }
+        }
+      }
+    }
+  },
+  "run_list":[
+    "recipe[arcgis-enterprise::portal_security]"
+  ]
+}


### PR DESCRIPTION
This commit enables the arcgis-enterprise cookbook to set Portal's identity store

Add a new recipe : portal_security

## **portal_security**
Configures Portal identity stores 

Attributes used by the recipe:

```
{
  "arcgis": {
    "portal": {
      "admin_username": "admin",
      "admin_password": "changeit",
      "security": {
        "user_store_config" : {
          "type" : "BUILTIN",
          "properties" : {
          }
        },
        "role_store_config" : {
          "type" : "BUILTIN",
          "properties" : {
          }
        }
      }
    }
  },
  "run_list": [
    "recipe[arcgis-enterprise::portal_security]"
  ]
}
```

New example file : roles\portal-windows-security.json

```
{
  "arcgis":{
    "run_as_password":"Run_As_Pa$$w0rd",
    "run_as_user":"arcgis",
    "version":"10.5",
    "portal":{
      "admin_username":"admin",
      "admin_password":"changeit",
      "admin_email":"admin@mydomain.com",
      "security_question":"Your favorite ice cream flavor?",
      "security_question_answer":"vanilla",
      "content_dir":"C:\\arcgisportal\\content",
      "setup":"C:\\ArcGIS\\10.5\\Portal\\Setup.exe",
      "authorization_file":"C:\\ArcGIS\\10.5\\Authorization_Files\\Portal.prvc",
      "keystore_file":"C:\\keystore\\mydomain_com.pfx",
      "keystore_password":"changeit",
      "security": {
        "user_store_config": {
          "type": "WINDOWS", 
          "properties": {
             "userPassword": "changeit",
             "isPasswordEncrypted": "false",
             "user": "DOMAIN\\user",
             "userFullnameAttribute": "cn",
             "userEmailAttribute": "mail",
             "caseSensitive": "false"
          }
        },
        "role_store_config": {
          "type": "WINDOWS", 
          "properties": {
            "user": "DOMAIN\\user",
            "userPassword": "changeit"
          }
        }
      }
    }
  },
  "run_list":[
    "recipe[arcgis-enterprise::portal_security]"
  ]
}

```
