### PR TITLE
Fix broken link in index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -104,7 +104,7 @@
               The fundamental setup of ArcGIS Enterprise is called the <b>base deployment</b>. This workflow automates the setup of a base ArcGIS Enterprise deployment on a single machine using Chef.
             </p>
           </div>
-          <a href="https://github.com/Esri/arcgis-cookbook/wiki/Deploy-a-full-stack-ArcGIS-Enterprise-on-a-single-machine" class="btn btn-clear btn-fill">See the workflow</a>
+          <a href="https://github.com/Esri/arcgis-cookbook/wiki/Deploy-a-base-ArcGIS-Enterprise-deployment-on-a-single-machine" class="btn btn-clear btn-fill">See the workflow</a>
         </div>
         <div class="card block trailer-4">
           <figure class="card-image-wrap">


### PR DESCRIPTION
Seems the "Create a base deployment" wiki article was renamed recently.