### PR TITLE
#393 Updated docker cookbook dependency version to '~> 11.3' (3.8.0)

### DIFF
--- a/cookbooks/arcgis-notebooks/CHANGELOG.md
+++ b/cookbooks/arcgis-notebooks/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This file is used to list changes made in each version of the arcgis-notebooks cookbook.
 
+# 3.8.1
+
+- Updated docker cookbook dependency version to '~> 11.3'.
+
 # 3.8.0
 
 - Added support for ArcGIS Notebook Server 10.9.1.

--- a/cookbooks/arcgis-notebooks/metadata.rb
+++ b/cookbooks/arcgis-notebooks/metadata.rb
@@ -4,12 +4,12 @@ maintainer_email 'contracts@esri.com'
 license 'Apache-2.0'
 description 'Installs/Configures ArcGIS Notebook Server'
 long_description 'Installs/Configures ArcGIS Notebook Server'
-version '3.8.0'
+version '3.8.1'
 chef_version '>= 13.0' if defined? chef_version
 
 depends          'arcgis-enterprise', '~> 3.8'
 depends          'arcgis-repository', '~> 3.8'
-depends          'docker', '~> 4.9'
+depends          'docker', '~> 11.3'
 depends          'iptables', '~> 7.1'
 
 supports         'ubuntu'

--- a/cookbooks/arcgis/Berksfile
+++ b/cookbooks/arcgis/Berksfile
@@ -19,7 +19,7 @@ group :release do
   cookbook 'esri-tomcat', path: '../esri-tomcat'
   # Lock versions of the dependent cookbooks  
   cookbook 'apt', '~> 7.4'
-  cookbook 'docker', '~> 4.12'
+  cookbook 'docker', '~> 11.3'
   cookbook 'homebrew', '~> 5.2'
   cookbook 'hostsfile', '~> 3.0'
   cookbook 'iptables', '~> 7.1'


### PR DESCRIPTION
The PR updates docker cookbook dependency in arcgis-notebooks 3.8.0 cookbook and changes the cookbook version to 3.8.1.

> The PR is created just to compare the changes. Do not install!