### PR TITLE
Added home discovery to arcgis-enterprise esri_properties

### DIFF
--- a/cookbooks/arcgis-enterprise/libraries/esri_properties.rb
+++ b/cookbooks/arcgis-enterprise/libraries/esri_properties.rb
@@ -19,8 +19,16 @@ require 'java-properties'
 
 module EsriProperties
 
+  def self.get_home(user)
+    cmd = Mixlib::ShellOut.new("getent passwd \"#{user}\" | cut -d: -f6 | awk '{printf $0}'", {:user => user})
+    cmd.run_command
+    return "/home/#{user}" if cmd.error?
+    
+    cmd.stdout
+  end
+
   def self.esri_properties(user, hostname, arcgis_version)
-    properties_file_path = "/home/#{user}/.ESRI.properties.*.#{arcgis_version}"
+    properties_file_path = "#{self.get_home(user)}/.ESRI.properties.*.#{arcgis_version}"
 
     cmd = Mixlib::ShellOut.new("cat #{properties_file_path}", { :user => user })
     cmd.run_command


### PR DESCRIPTION
## The problem

We're installing ArcGIS enterprise with a user in a non-standard home directory (in our case, `/arcgis` instead of `/home/arcgis`) and encountered a problem with multiple converges: ArcGIS Portal and Server attempt to reinstall on the second converge. 

Specifically, the ArcGIS Portal and Server installers are crashing on the second converge (because their products are already installed). They shouldn't even be running in the first place!

## What is happening
- The resource `arcgis_enterprise_portal 'Install Portal for ArcGIS'` is executing on the second converge, even though Portal for ArcGIS is already installed ([this resource is declared here](https://github.com/Esri/arcgis-cookbook/blob/main/cookbooks/arcgis-enterprise/recipes/install_portal.rb))
- ditto for server ([declared here](https://github.com/Esri/arcgis-cookbook/blob/main/cookbooks/arcgis-enterprise/recipes/install_server.rb))

The resources which install Portal and Server have `not_if` guards on them. These guards are dependent on the `esri_properties` module (https://github.com/Esri/arcgis-cookbook/blob/main/cookbooks/arcgis-enterprise/libraries/esri_properties.rb).

That module should:
1. identify the relevant ESRI Properties file in the installing user's home folder
2. parse it
3. return true if the relevant product is installed

Right now, it does Step 1 under the assumption that the user's home folder is under `/home` and has the same name as the user:
```ruby
properties_file_path = "/home/#{user}/.ESRI.properties.*.#{arcgis_version}"
```

## What this commit changes
Replaced current home path substitution with new shellout command to dynamically discover a users home directory
- Before, the `esri_properties` module would assume the installing user's home directory was located under `/home/username`
- Now, `esri_properties` will discover the home directory via `getent passwd \"#{user}\" | cut -d: -f6 | awk '{printf $0}'`
  - `getend passwd \"#{user}\"` actually returns a passwd line for the user
  - `cut -d: -f6` extracts the home directory`
  - `awk '{printf $0}'` removes the newline

Effectively, the esri_properties.rb now contains:

```ruby
def self.get_home(user)
  cmd = Mixlib::ShellOut.new("getent passwd \"#{user}\" | cut -d: -f6 | awk '{printf $0}'", {:user => user})
  cmd.run_command
  return "/home/#{user}" if cmd.error?

  cmd.stdout
end

def self.esri_properties(user, hostname, arcgis_version)
  properties_file_path = "#{self.get_home(user)}/.ESRI.properties.*.#{arcgis_version}"
  # ... the rest
```

This will accommodate use-cases where the installing user's home directory is not under `/home`.