### PR TITLE
Add back versions.md

### DIFF
--- a/versions.md
+++ b/versions.md
@@ -1,0 +1,7 @@
+---
+layout: none
+---
+<meta http-equiv="refresh" content="0; url=/arcgis-cookbook/versions/5.3.0.html">
+<link rel="canonical" href="/arcgis-cookbook/versions/5.3.0.html">
+<p>Redirecting to <a href="/arcgis-cookbook/versions/5.3.0.html">/arcgis-cookbook/versions/5.3.0.html</a>...</p>
+<script>window.location.href = "/arcgis-cookbook/versions/5.3.0.html";</script>


### PR DESCRIPTION
Added back versions.md file with redirect to the latest version to fix broken https://esri.github.io/arcgis-cookbook/versions.html link in the ArcGIS Enterprise docs.